### PR TITLE
Lista eventos -> Botones ocultos para no coordinadores

### DIFF
--- a/src/java/controladores/MiSesion.java
+++ b/src/java/controladores/MiSesion.java
@@ -5,6 +5,7 @@
  */
 package controladores;
 
+import clases.Perfil;
 import clases.Usuario;
 import javax.inject.Named;
 import javax.enterprise.context.SessionScoped;
@@ -81,6 +82,10 @@ public class MiSesion implements Serializable {
      */
     public void setUsers(List<Usuario> users) {
         this.users = users;
+    }
+    
+    public boolean isCoord() {
+        return this.user.getPerfiles().getRol().equals(Perfil.Rol.COORDGEN);
     }
     
 }

--- a/web/Lista_eventos.xhtml
+++ b/web/Lista_eventos.xhtml
@@ -14,10 +14,14 @@
     <ui:define name="title">Eventos</ui:define>
 
     <ui:define name="content">
-        <div class = "container-fluid">
-            <button type="button" class="btn btn-success" href="#">CREAR EVENTO +</button>
-        </div>
-        <br/>
+        <c:choose>
+            <c:when test="#{miSesion.isCoord()}">
+                <div class = "container-fluid">
+                    <button type="button" class="btn btn-success" href="#">CREAR EVENTO +</button>
+                </div>
+                <br/>
+            </c:when>
+        </c:choose>
         <div class="container-fluid">
             <p:dataTable var="events" value="#{Eventos.eventosj}">
                 <p:column headerText="Titulo">
@@ -41,11 +45,15 @@
                         <f:param name="Evento" value="#{events.id}"/>
                     </p:link>	
                 </p:column>
-                <p:column headerText="Borrar">
-                    <h:form>
-                        <p:commandButton value="Eliminar" ajax="false" actionListener="#{Eventos.borrarEvento(events.id)}"></p:commandButton>
-                    </h:form>
-                </p:column>
+                <c:choose>
+                    <c:when test="#{miSesion.isCoord()}">
+                        <p:column headerText="Borrar">
+                            <h:form>
+                                <p:commandButton value="Eliminar" ajax="false" actionListener="#{Eventos.borrarEvento(events.id)}"></p:commandButton>
+                            </h:form>
+                        </p:column>
+                    </c:when>
+                </c:choose>
             </p:dataTable>
         </div>
     </ui:define>


### PR DESCRIPTION
He puesto que los que no sean del rol coordinador general no puedan ni borrar ni añadir eventos. Falta el tema de los coordinadores de sección, porque no sé si controlamos de alguna forma que un evento sea de una sección específica.